### PR TITLE
chore: enhance health endpoint

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -25,6 +25,6 @@ springdoc.swagger-ui.operationsSorter=null
 server.forward-headers-strategy=framework
 
 # Actuator
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=when_authorized
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
 


### PR DESCRIPTION
This pull request makes a minor update to the actuator endpoint configuration in the `application-prod.properties` file to restrict exposed management endpoints and hide health details by default.

- Production configuration changes:
  * Limited the exposed actuator endpoints to only `health` and set health details to never be shown, enhancing security for production environments.